### PR TITLE
Collider heat source

### DIFF
--- a/Heat Source Types/ColliderHeatSource.cs
+++ b/Heat Source Types/ColliderHeatSource.cs
@@ -1,0 +1,84 @@
+﻿using UnityEngine;
+
+[RequireComponent(typeof(Collider))]
+public class ColliderHeatSource : HeatSource
+{
+    [SerializeField, Range(-100f, 100f), Tooltip("Temperature in Degrees Celcius")]
+    float sourceTemperature = 50f; //Temperature of the heat source
+    public float SourceTemperature
+    {
+        get { return sourceTemperature; }
+        set { sourceTemperature = value; }
+    }
+
+    Collider col = null;
+    Mesh mesh = null;
+
+    void OnValidate()
+    {
+        col = GetComponent<Collider>();
+        MeshCollider mc = GetComponent<MeshCollider>();
+        if (mc != null)
+        {
+            mesh = mc.sharedMesh;
+        }
+    }
+
+    protected override void Awake()
+    {
+        OnValidate();
+        base.Awake();
+    }
+
+
+    //Currently only draw rectangular bounds but will look into changing for the future to more accurately draw other collider shapes
+    void OnDrawGizmos()
+    {
+        Bounds bounds = col.bounds;
+        Vector3 center = bounds.center;
+        Quaternion rotation = transform.rotation;
+        Gizmos.color = Color.green;
+        /*
+        if(mesh != null)
+        {
+            Gizmos.DrawWireMesh(mesh, center, rotation);
+        }
+        else
+        {*/
+            Vector3 min = bounds.min;
+            Vector3 max = bounds.max;
+
+            //Bottom rectangle
+            Gizmos.DrawLine(min, new Vector3(min.x, min.y, max.z));
+            Gizmos.DrawLine(min, new Vector3(max.x, min.y, min.z));
+            Gizmos.DrawLine(new Vector3(max.x, min.y, max.z), new Vector3(min.x, min.y, max.z));
+            Gizmos.DrawLine(new Vector3(max.x, min.y, max.z), new Vector3(max.x, min.y, min.z));
+
+            //Top rectangle
+            Gizmos.DrawLine(new Vector3(min.x, max.y, min.z), new Vector3(min.x, max.y, max.z));
+            Gizmos.DrawLine(new Vector3(min.x, max.y, min.z), new Vector3(max.x, max.y, min.z));
+            Gizmos.DrawLine(new Vector3(max.x, max.y, max.z), new Vector3(min.x, max.y, max.z));
+            Gizmos.DrawLine(new Vector3(max.x, max.y, max.z), new Vector3(max.x, max.y, min.z));
+
+            //Vertical lines
+            Gizmos.DrawLine(min, new Vector3(min.x, max.y, min.z));
+            Gizmos.DrawLine(new Vector3(max.x, min.y, max.z), new Vector3(max.x, max.y, max.z));
+            Gizmos.DrawLine(new Vector3(min.x, min.y, max.z), new Vector3(min.x, max.y, max.z));
+            Gizmos.DrawLine(new Vector3(max.x, min.y, min.z), new Vector3(max.x, max.y, min.z));
+        //}
+
+    }
+
+
+    //If the point is within the bounds of the collider it recieves the full contribution, otherwise no contibution
+    public override float GetTemperatureContribution(Vector3 position)
+    {
+        if (col.bounds.Contains(position))
+        {
+            return sourceTemperature;
+        } else
+        {
+            return 0f;
+        }
+    }
+}

--- a/Heat Source Types/ColliderHeatSource.cs
+++ b/Heat Source Types/ColliderHeatSource.cs
@@ -12,16 +12,10 @@ public class ColliderHeatSource : HeatSource
     }
 
     Collider col = null;
-    Mesh mesh = null;
 
     void OnValidate()
     {
         col = GetComponent<Collider>();
-        MeshCollider mc = GetComponent<MeshCollider>();
-        if (mc != null)
-        {
-            mesh = mc.sharedMesh;
-        }
     }
 
     protected override void Awake()
@@ -30,55 +24,23 @@ public class ColliderHeatSource : HeatSource
         base.Awake();
     }
 
-
-    //Currently only draw rectangular bounds but will look into changing for the future to more accurately draw other collider shapes
-    void OnDrawGizmos()
-    {
-        Bounds bounds = col.bounds;
-        Vector3 center = bounds.center;
-        Quaternion rotation = transform.rotation;
-        Gizmos.color = Color.green;
-        /*
-        if(mesh != null)
-        {
-            Gizmos.DrawWireMesh(mesh, center, rotation);
-        }
-        else
-        {*/
-            Vector3 min = bounds.min;
-            Vector3 max = bounds.max;
-
-            //Bottom rectangle
-            Gizmos.DrawLine(min, new Vector3(min.x, min.y, max.z));
-            Gizmos.DrawLine(min, new Vector3(max.x, min.y, min.z));
-            Gizmos.DrawLine(new Vector3(max.x, min.y, max.z), new Vector3(min.x, min.y, max.z));
-            Gizmos.DrawLine(new Vector3(max.x, min.y, max.z), new Vector3(max.x, min.y, min.z));
-
-            //Top rectangle
-            Gizmos.DrawLine(new Vector3(min.x, max.y, min.z), new Vector3(min.x, max.y, max.z));
-            Gizmos.DrawLine(new Vector3(min.x, max.y, min.z), new Vector3(max.x, max.y, min.z));
-            Gizmos.DrawLine(new Vector3(max.x, max.y, max.z), new Vector3(min.x, max.y, max.z));
-            Gizmos.DrawLine(new Vector3(max.x, max.y, max.z), new Vector3(max.x, max.y, min.z));
-
-            //Vertical lines
-            Gizmos.DrawLine(min, new Vector3(min.x, max.y, min.z));
-            Gizmos.DrawLine(new Vector3(max.x, min.y, max.z), new Vector3(max.x, max.y, max.z));
-            Gizmos.DrawLine(new Vector3(min.x, min.y, max.z), new Vector3(min.x, max.y, max.z));
-            Gizmos.DrawLine(new Vector3(max.x, min.y, min.z), new Vector3(max.x, max.y, min.z));
-        //}
-
-    }
-
-
     //If the point is within the bounds of the collider it recieves the full contribution, otherwise no contibution
     public override float GetTemperatureContribution(Vector3 position)
     {
         if (col.bounds.Contains(position))
         {
             return sourceTemperature;
-        } else
+        } 
+        else
         {
             return 0f;
         }
+    }
+
+    public override void InitialiseHeatSource(float sourceTemperature, float heatRange, float heatFalloffRange, float angle)
+    {
+        this.sourceTemperature = sourceTemperature;
+        Debug.Log(transform.rotation);
+        transform.rotation = Quaternion.Euler(-90f, angle, transform.rotation.z);
     }
 }

--- a/Heat Source Types/ColliderHeatSource.cs.meta
+++ b/Heat Source Types/ColliderHeatSource.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7ec2748298700a748a12559618ad696d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Heat Source Types/HeatSource.cs
+++ b/Heat Source Types/HeatSource.cs
@@ -4,6 +4,7 @@
 //override with their own implementation if needed.
 public class HeatSource : MonoBehaviour
 {
+    //If child classes override Awake they should always call the base implementation as well
     protected virtual void Awake()
     {
         TemperatureControl.RegisterHeatSource(this);

--- a/Heat Source Types/HeatSource.cs
+++ b/Heat Source Types/HeatSource.cs
@@ -19,4 +19,9 @@ public class HeatSource : MonoBehaviour
     {
         return 0f;
     }
+
+    public virtual void InitialiseHeatSource(float sourceTemperature, float heatRange, float heatFalloffRange, float angle)
+    {
+
+    }
 }

--- a/Heat Source Types/RadiusHeatSource.cs
+++ b/Heat Source Types/RadiusHeatSource.cs
@@ -66,4 +66,12 @@ public class RadiusHeatSource : HeatSource
         }
         return tempContribution;
     }
+
+    //Set heating parameters
+    public override void InitialiseHeatSource(float sourceTemperature, float heatRange, float heatFalloffRange, float angle)
+    {
+        this.sourceTemperature = sourceTemperature;
+        this.heatRange = heatRange;
+        this.heatFalloffRange = heatFalloffRange;
+    }
 }

--- a/HeatSourcePlacement.cs
+++ b/HeatSourcePlacement.cs
@@ -1,60 +1,93 @@
 ﻿using UnityEngine;
 using TMPro;
+using System;
+using System.Collections.Generic;
 
+//Allows users to configure and place heat source prefabs into the scene with left click
 public class HeatSourcePlacement : MonoBehaviour
 {
     [SerializeField]
-    RadiusHeatSource placeableObject;
+    HeatSource placeableObject = default;
 
     [SerializeField]
-    TMP_InputField tempInput, rangeInput, rangeFalloffInput;
+    List<HeatSource> heatSourcePrefabs = new List<HeatSource>();
 
+    [SerializeField]
+    TMP_Dropdown heatSourceTypeInput = default;
+
+    [SerializeField]
+    TMP_InputField tempInput = default, rangeInput = default, rangeFalloffInput = default, angleInput = default;
+
+    [SerializeField]
+    GameObject rangeSettingsContainer = default, angleSettingsContainer = default;
+
+    enum HeatSourceType { Radius, Collider};
+    HeatSourceType heatSourceType = HeatSourceType.Radius;
     Camera mainCamera;
-    float sourceTemperature = 50f, heatRange = 1.5f, heatFalloffRange = 3.5f;
+    float sourceTemperature = 50f, heatRange = 1.5f, heatFalloffRange = 3.5f, angle = 0f;
 
     void Awake()
     {
         mainCamera = Camera.main;
-        tempInput.onValueChanged.AddListener(delegate { TempInputChanged(); });
-        rangeInput.onValueChanged.AddListener(delegate { RangeInputChanged(); });
-        rangeFalloffInput.onValueChanged.AddListener(delegate { RangeFalloffInputChanged(); });
-        sourceTemperature = float.Parse(tempInput.text);
-        heatRange = float.Parse(rangeInput.text);
+
+        //Set the options of the dropdown menu to the values set in the enum, guarantees that when enum values change dropdown options still match
+        heatSourceTypeInput.onValueChanged.AddListener(delegate { HeatSourceTypeChange(); });
+        heatSourceTypeInput.ClearOptions();
+        List<string> strings = new List<string>();
+        foreach(string value in Enum.GetNames(typeof(HeatSourceType)))
+        {
+            strings.Add(value);
+        }
+        heatSourceTypeInput.AddOptions(strings);
+
+        //Create delegate functions to update variables when UI values change
+        tempInput.onValueChanged.AddListener(delegate { float.TryParse(tempInput.text, out sourceTemperature); });
+        rangeInput.onValueChanged.AddListener(delegate { float.TryParse(rangeInput.text, out heatRange); });
+        rangeFalloffInput.onValueChanged.AddListener(delegate { float.TryParse(rangeFalloffInput.text, out heatFalloffRange); });
+        angleInput.onValueChanged.AddListener(delegate { float.TryParse(angleInput.text, out angle); });
+        float.TryParse(tempInput.text, out sourceTemperature);
+        float.TryParse(rangeInput.text, out heatRange);
+
+        //Initialise UI
+        HeatSourceTypeChange();
     }
 
     void Update()
     {
+        //If left mouse clicked on a surface spawn new heat source on that surface 
         if (Input.GetMouseButtonDown(0))
         {
             Ray ray = mainCamera.ScreenPointToRay(Input.mousePosition);
             RaycastHit hit;
-            int layerMask = 1 << 8;
+            int layerMask = 1 << 8; //Layer 8 = PlaceableSurface
             if(Physics.Raycast(ray, out hit, Mathf.Infinity, layerMask))
             {
                 Quaternion spawnRotation = Quaternion.FromToRotation(Vector3.up, hit.normal);
                 Vector3 spawnPoint = hit.point + (hit.normal * (placeableObject.transform.localScale.y * 0.5f));
                 Debug.Log(hit.point + (hit.normal * (placeableObject.transform.localScale.y * 0.5f)));
-                RadiusHeatSource sourceObject = Instantiate(placeableObject, spawnPoint, spawnRotation);
-                sourceObject.SourceTemperature = sourceTemperature;
-                sourceObject.HeatRange = heatRange;
-                sourceObject.HeatFalloffRange = heatFalloffRange;
-                Debug.LogFormat("New Heat Source: Temp = {0}, Range = {1}, Falloff = {2}", sourceTemperature, heatRange, heatFalloffRange);
+                HeatSource sourceObject = Instantiate(placeableObject, spawnPoint, spawnRotation);
+                sourceObject.InitialiseHeatSource(sourceTemperature, heatRange, heatFalloffRange, angle);
             }
         }
     }
 
-    void TempInputChanged()
+    //When heat source drop down menu changes, update the selected heat source type variable and change UI to show correct settings
+    void HeatSourceTypeChange()
     {
-        sourceTemperature = float.Parse(tempInput.text);
-    }
-
-    void RangeInputChanged()
-    {
-        heatRange = float.Parse(rangeInput.text);
-    }
-
-    void RangeFalloffInputChanged()
-    {
-        heatFalloffRange = float.Parse(rangeFalloffInput.text);
+        heatSourceType = (HeatSourceType)heatSourceTypeInput.value;
+        placeableObject = heatSourcePrefabs[heatSourceTypeInput.value];
+        switch (heatSourceType)
+        {
+            case HeatSourceType.Radius:
+                rangeSettingsContainer.gameObject.SetActive(true);
+                angleSettingsContainer.gameObject.SetActive(false);
+                break;
+            case HeatSourceType.Collider:
+                rangeSettingsContainer.gameObject.SetActive(false);
+                angleSettingsContainer.gameObject.SetActive(true);
+                break;
+            default:
+                break;
+        }
     }
 }

--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ Heat Source - parent class for components that generate heat in the scene, funct
 Radius Heat Source - child of heat source, objects within a set radius receive the full temperature contribution, beyond radius
 		     contribution falls off by 1/x^2 as object approaces falloff radius beyond which contribution is 0.
 
+Collider Heat Source - child of heat source, any temperature monitors within the game objects collider recieve the full temperature 
+		       contribution
+
 Temperature Monitor - checks the temperature control class for its current temperature
 
 Temperature Colour Change - checks temperature monitor component and changes material colour (hot = red, cold = blue) and UI elements

--- a/TemperatureColourChange.cs
+++ b/TemperatureColourChange.cs
@@ -6,7 +6,7 @@ using TMPro;
 public class TemperatureColourChange : MonoBehaviour
 {
     [SerializeField]
-    TextMeshProUGUI displayText;
+    TextMeshProUGUI displayText = default;
 
     [SerializeField]
     float minTemp = 0f, maxTemp = 75f, hotHue = 0f, coldHue = 240f;


### PR DESCRIPTION
Added new Heat Source child - Collider Heat Source. Must be used with a game object with a collider. Provides full temperature contribution to any temperature monitors within the collider. Modified other scripts to account for different heat source children having different requirements for spawning and temperature calculations.